### PR TITLE
allow setting file extension for vault path generation

### DIFF
--- a/handler/cantabular_metadata_export.go
+++ b/handler/cantabular_metadata_export.go
@@ -136,7 +136,7 @@ func (h *CantabularMetadataExport) exportTXTFile(ctx context.Context, e *event.C
 	if isPublished{
 		url, err = h.file.Upload(bytes.NewReader(b), h.generateTextFilename(e))
 	} else {
-		url, err = h.file.UploadPrivate(bytes.NewReader(b), h.generateTextFilename(e), h.generateVaultPath(e))
+		url, err = h.file.UploadPrivate(bytes.NewReader(b), h.generateTextFilename(e), h.generateVaultPath(e, "txt"))
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload file: %w", err)
@@ -171,7 +171,7 @@ func (h *CantabularMetadataExport) exportCSVW(ctx context.Context, e *event.CSVC
 	if isPublished {
 		url, err = h.file.Upload(bytes.NewReader(f), filename)
 	} else {
-		url, err = h.file.UploadPrivate(bytes.NewReader(f), filename, h.generateVaultPath(e))
+		url, err = h.file.UploadPrivate(bytes.NewReader(f), filename, h.generateVaultPath(e, "csvw"))
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload file: %w", err)
@@ -217,8 +217,8 @@ func (h *CantabularMetadataExport) generateDownloadURL(e *event.CSVCreated) stri
 }
 
 // generateVaultPathForFile generates the vault path for the provided root and filename
-func (h *CantabularMetadataExport) generateVaultPath(e *event.CSVCreated) string {
-	return fmt.Sprintf("%s/%s-%s-%s.txt", h.cfg.VaultPath, e.DatasetID, e.Edition, e.Version)
+func (h *CantabularMetadataExport) generateVaultPath(e *event.CSVCreated, filetype string) string {
+	return fmt.Sprintf("%s/%s-%s-%s.%s", h.cfg.VaultPath, e.DatasetID, e.Edition, e.Version, filetype)
 }
 
 // getText gets a byte array containing the metadata content, based on options returned by dataset API.

--- a/handler/cantabular_metadata_export_test.go
+++ b/handler/cantabular_metadata_export_test.go
@@ -33,12 +33,17 @@ func TestGenerateTextFilename(t *testing.T) {
 
 func TestGenerateVaultPath(t *testing.T) {
 
-	Convey("Succesfully return a string representing the vault path", t, func() {
+	Convey("Succesfully return a string representing the vault path with given file extension", t, func() {
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)
 		h := NewCantabularMetadataExport(*cfg, nil, nil, nil)
-		vaultPath := h.generateVaultPath(&eventTest)
-		expectedVaultPath := "secret/shared/psk/test_id-test-edition-1.txt"
+
+		vaultPath := h.generateVaultPath(&eventTest, "foo")
+		expectedVaultPath := "secret/shared/psk/test_id-test-edition-1.foo"
+		So(vaultPath, ShouldResemble, expectedVaultPath)
+
+		vaultPath = h.generateVaultPath(&eventTest, "bar")
+		expectedVaultPath = "secret/shared/psk/test_id-test-edition-1.bar"
 		So(vaultPath, ShouldResemble, expectedVaultPath)
 
 	})

--- a/handler/cantabular_metadata_export_test.go
+++ b/handler/cantabular_metadata_export_test.go
@@ -38,14 +38,17 @@ func TestGenerateVaultPath(t *testing.T) {
 		So(err, ShouldBeNil)
 		h := NewCantabularMetadataExport(*cfg, nil, nil, nil)
 
-		vaultPath := h.generateVaultPath(&eventTest, "foo")
-		expectedVaultPath := "secret/shared/psk/test_id-test-edition-1.foo"
-		So(vaultPath, ShouldResemble, expectedVaultPath)
+		Convey("Vault path ends in 'foo'", func() {
+			vaultPath := h.generateVaultPath(&eventTest, "foo")
+			expectedVaultPath := "secret/shared/psk/test_id-test-edition-1.foo"
+			So(vaultPath, ShouldResemble, expectedVaultPath)
+		})
 
-		vaultPath = h.generateVaultPath(&eventTest, "bar")
-		expectedVaultPath = "secret/shared/psk/test_id-test-edition-1.bar"
-		So(vaultPath, ShouldResemble, expectedVaultPath)
-
+		Convey("Vault path ends in 'bar'", func() {
+			vaultPath := h.generateVaultPath(&eventTest, "bar")
+			expectedVaultPath := "secret/shared/psk/test_id-test-edition-1.bar"
+			So(vaultPath, ShouldResemble, expectedVaultPath)
+		})
 	})
 
 }


### PR DESCRIPTION
### What

Allow passing of file extension for vault path generation to set separate vault paths for txt and csvw files.

### How to review

Check code change makes sense, tests pass

### Who can review

Anyone
