### PR TITLE
Feature/fix geog dimension metadata

### DIFF
--- a/handler/cantabular_metadata_export.go
+++ b/handler/cantabular_metadata_export.go
@@ -150,27 +150,25 @@ func (h *CantabularMetadataExport) Handle(ctx context.Context, workerID int, msg
 
 		areaTypeFound = false
 
-		for _, d := range m.Version.Dimensions {
+		for i, d := range m.Version.Dimensions {
 			if *d.IsAreaType {
-				d.Label = areaTypeLabel
-				d.Description = areaTypeDescription
-				d.ID = areaTypeId
-				d.NumberOfOptions = numberOfOptions
+				m.Version.Dimensions[i].Label = areaTypeLabel
+				m.Version.Dimensions[i].Description = areaTypeDescription
+				m.Version.Dimensions[i].ID = areaTypeId
+				m.Version.Dimensions[i].NumberOfOptions = numberOfOptions
 				areaTypeFound = true
 				break
 			}
 		}
 
 		if !areaTypeFound {
-			areaTypeDimension := []dataset.VersionDimension{
-				{
-					Label:           areaTypeLabel,
-					Description:     areaTypeDescription,
-					ID:              areaTypeId,
-					NumberOfOptions: numberOfOptions,
-				},
+			areaTypeDimension := dataset.VersionDimension{
+				Label:           areaTypeLabel,
+				Description:     areaTypeDescription,
+				ID:              areaTypeId,
+				NumberOfOptions: numberOfOptions,
 			}
-			m.Version.Dimensions = append(m.Version.Dimensions, areaTypeDimension...)
+			m.Version.Dimensions = append(m.Version.Dimensions, areaTypeDimension)
 		}
 	}
 

--- a/handler/cantabular_metadata_export.go
+++ b/handler/cantabular_metadata_export.go
@@ -99,6 +99,7 @@ func (h *CantabularMetadataExport) Handle(ctx context.Context, workerID int, msg
 	}
 
 	if e.FilterOutputID != "" {
+		fmt.Printf("********** FILTER OUTPUT ID %v\n ******************", e.FilterOutputID)
 		filterModel, err := h.filter.GetOutput(ctx, "", h.cfg.ServiceAuthToken, "", "", e.FilterOutputID)
 		if err != nil {
 			return &Error{
@@ -130,10 +131,12 @@ func (h *CantabularMetadataExport) Handle(ctx context.Context, workerID int, msg
 			if fd.IsAreaType != nil {
 				if *fd.IsAreaType {
 					areaTypeLabel = fd.Label
+					fmt.Printf("********** AREA TYPE LABEL %v\n ******************", areaTypeLabel)
 				}
 				for _, area := range areaType.AreaTypes {
 					if area.Label == fd.Label {
 						areaTypeDescription = area.Description
+						fmt.Printf("********** AREA TYPE DESCRIPTION %v\n ******************", areaTypeDescription)
 						areaTypeFound = true
 						break
 					}
@@ -145,12 +148,18 @@ func (h *CantabularMetadataExport) Handle(ctx context.Context, workerID int, msg
 		}
 		for _, d := range m.Version.Dimensions {
 			if *d.IsAreaType {
+
 				d.Label = areaTypeLabel
 				d.Description = areaTypeDescription
+				fmt.Printf("********** AREA TYPE LABEL AFTER LOOP %v\n ******************", d.Label)
+				fmt.Printf("********** AREA TYPE DESCRIPTION AFTER LOOP %v\n ******************", d.Label)
 				break
 			}
 		}
 	}
+
+	fmt.Printf("********** METADATA AREA TYPE DESCRIPTION %v\n ******************", m.Dimensions[0].Description)
+	fmt.Printf("********** METADATA AREA TYPE LABEL %v\n ******************", m.Dimensions[0].Label)
 
 	isPublished, err := h.isVersionPublished(ctx, e)
 	if err != nil {

--- a/handler/cantabular_metadata_export.go
+++ b/handler/cantabular_metadata_export.go
@@ -152,7 +152,7 @@ func (h *CantabularMetadataExport) Handle(ctx context.Context, workerID int, msg
 				d.Label = areaTypeLabel
 				d.Description = areaTypeDescription
 				fmt.Printf("********** AREA TYPE LABEL AFTER LOOP %v\n ******************", d.Label)
-				fmt.Printf("********** AREA TYPE DESCRIPTION AFTER LOOP %v\n ******************", d.Label)
+				fmt.Printf("********** AREA TYPE DESCRIPTION AFTER LOOP %v\n ******************", d.Description)
 				break
 			}
 		}


### PR DESCRIPTION
### What

Fix for updated geography dimension not being added to metadata on filtered dataset

This fix is to address the issue with the original PR for this ticket (https://github.com/ONSdigital/dp-cantabular-metadata-exporter/pull/62), which when tested in sandbox was still not pulling through the updated geography dimension in the csvw and txt metadata files

Trello - https://trello.com/c/MGF4L4rT/5950-get-meta-data-for-area-type-selection-to-show-on-custom-data-set-output-files

### How to review

Confirm changes make sense and match requested changes in Trello ticket

### Who can review

Anyone
